### PR TITLE
chore: include DR's dependency in core install

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -39,6 +39,7 @@ jobs:
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/vars.lic > lich5/scripts/vars.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/version.lic > lich5/scripts/version.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/xnarost.lic > lich5/scripts/xnarost.lic
+          curl https://raw.githubusercontent.com/rpherbig/dr-scripts/master/dependency.lic > lich5/scripts/dependency.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/spell-list.xml > lich5/data/spell-list.xml
           cp lich.rbw Lich5/
           cp -r lib Lich5/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/vars.lic > lich5/scripts/vars.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/version.lic > lich5/scripts/version.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/xnarost.lic > lich5/scripts/xnarost.lic
+          curl https://raw.githubusercontent.com/rpherbig/dr-scripts/master/dependency.lic > lich5/scripts/dependency.lic
           curl https://raw.githubusercontent.com/elanthia-online/scripts/master/scripts/spell-list.xml > lich5/data/spell-list.xml
           cp lich.rbw lich5/
           cp -r lib lich5/


### PR DESCRIPTION
This allows DR to convert to dependency without the need to connect to `;repo`