### PR TITLE
fix(gs): migrate PSMS.name_normal to Lich::Util.name_normal (#790)

### DIFF
--- a/lib/gemstone/psms.rb
+++ b/lib/gemstone/psms.rb
@@ -12,15 +12,7 @@ module Lich
   module Gemstone
     module PSMS
       def self.name_normal(name)
-        # there are five cases to normalize
-        # "vault_kick", "vault kick", "vault-kick", :vault_kick, :vaultkick
-        # "predator's eye"
-        # if present, convert spaces to underscore; convert all to downcase string
-        normal_name = name.to_s.downcase
-        normal_name.gsub!(' ', '_') if name =~ (/\s/)
-        normal_name.gsub!('-', '_') if name =~ (/-/)
-        normal_name.gsub!("'", '') if name =~ (/'/)
-        normal_name
+        Lich::Util.name_normal(name)
       end
 
       def self.find_name(name, type)

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -43,6 +43,18 @@ module Lich
       end
     end
 
+    def self.name_normal(name)
+      # there are five cases to normalize
+      # "vault_kick", "vault kick", "vault-kick", :vault_kick, :vaultkick
+      # "predator's eye"
+      # if present, convert spaces to underscore; convert all to downcase string
+      normal_name = name.to_s.downcase
+      normal_name.gsub!(' ', '_') if name =~ (/\s/)
+      normal_name.gsub!('-', '_') if name =~ (/-/)
+      normal_name.gsub!("'", '') if name =~ (/'/)
+      normal_name
+    end
+
     ## Lifted from LR foreach.lic
 
     def self.anon_hook(prefix = '')

--- a/spec/psms_spec.rb
+++ b/spec/psms_spec.rb
@@ -39,6 +39,7 @@ LIB_DIR = File.join(File.expand_path("..", File.dirname(__FILE__)), 'lib')
 
 require 'gemstone/psms'
 require 'gemstone/infomon'
+require 'util/util'
 
 module Char
   def self.name


### PR DESCRIPTION
Allows for usage of `name_normal` method to be utilized by other functions within Lich without the reference of PSMS to make it more generic usage.