### PR TITLE
fix(all): allow for :ignore as an end_pattern

### DIFF
--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -75,7 +75,7 @@ module Lich
     #
     # @param command [String] The command to send.
     # @param start_pattern [Regexp] Pattern marking the start of output capture.
-    # @param end_pattern [Regexp] Pattern marking the end of output capture. Defaults to /<prompt/.
+    # @param end_pattern [Regexp, Symbol] Pattern marking the end of output capture. Defaults to /<prompt/. Use :ignore for single-line capture.
     # @param include_end [Boolean] Whether to include the end line in the result. Defaults to true.
     # @param timeout [Integer] Timeout in seconds for the command. Defaults to 5.
     # @param silent [Boolean, nil] Whether to silence script output. Defaults to nil (no change).

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -80,10 +80,10 @@ module Lich
         Timeout::timeout(timeout, Interrupt) {
           DownstreamHook.add(name, proc { |line|
             if filter
-              if line =~ end_pattern
+              if end_pattern.eql?(:ignore) || line =~ end_pattern
                 DownstreamHook.remove(name)
                 filter = false
-                if quiet
+                if quiet && !end_pattern.eql?(:ignore)
                   next(nil)
                 else
                   line
@@ -112,10 +112,10 @@ module Lich
           result << line.rstrip
           until (line = get) =~ end_pattern
             result << line.rstrip
-          end
+          end unless end_pattern.eql?(:ignore)
           if include_end
             result << line.rstrip
-          end
+          end unless end_pattern.eql?(:ignore)
         }
       rescue Interrupt
         nil

--- a/lib/util/util.rb
+++ b/lib/util/util.rb
@@ -1,33 +1,23 @@
 =begin
 util.rb: Core lich file for collection of utilities to extend Lich capabilities.
 Entries added here should always be accessible from Lich::Util.feature namespace.
-
-    Maintainer: Elanthia-Online
-    Original Author: LostRanger, Ondreian, various others
-    game: Gemstone
-    tags: CORE, util, utilities
-    required: Lich > 5.0.19
-    version: 1.3.1
-
-  changelog:
-    v1.3.1 (2022-06-26)
-     * Fix to not squelch the end_pattern for issue_command if not a quiet command
-    v1.3.0 (2022-03-16)
-     * Add Lich::Util.issue_command that allows more fine-tooled control return
-     * Bugfix for Lich::Util.silver_count not using end_pattern properly
-    v1.2.0 (2022-03-16)
-     * Add Lich::Util.quiet_command to mimic XML version
-    v1.1.0 (2022-03-09)
-     * Fix silver_count forcing downstream_xml on
-    v1.0.0 (2022-03-08)
-     * Initial release
-
 =end
 
 module Lich
   module Util
     include Enumerable
 
+    # Normalizes and performs a lookup for an effect based on the provided value.
+    #
+    # Depending on the type of `val`, this method will:
+    # - For String: Check if the normalized string matches any key in the effect's hash (case-insensitive, underscores replaced with spaces).
+    # - For Integer: Check if the effect is active for the given integer value.
+    # - For Symbol: Check if the normalized symbol matches any key in the effect's hash (case-insensitive, underscores replaced with spaces).
+    #
+    # @param effect [String] The name of the effect class (without the "Effects::" prefix).
+    # @param val [String, Integer, Symbol] The value to look up; can be a string, integer, or symbol.
+    # @return [Boolean] True if the lookup is successful, false otherwise.
+    # @raise [RuntimeError] If `val` is not a String, Integer, or Symbol.
     def self.normalize_lookup(effect, val)
       caller_type = "Effects::#{effect}"
       case val
@@ -43,11 +33,25 @@ module Lich
       end
     end
 
+    # Normalizes a given name by converting it to a lowercase string and replacing or removing certain characters.
+    #
+    # The normalization process handles the following cases:
+    # - Converts spaces and hyphens to underscores.
+    # - Removes colons and apostrophes.
+    # - Converts symbols to strings.
+    # - Converts all characters to lowercase.
+    #
+    # Examples:
+    #   normalize_name("vault_kick")      #=> "vault_kick"
+    #   normalize_name("vault kick")      #=> "vault_kick"
+    #   normalize_name("vault-kick")      #=> "vault_kick"
+    #   normalize_name(:vault_kick)       #=> "vault_kick"
+    #   normalize_name(:vaultkick)        #=> "vaultkick"
+    #   normalize_name("predator's eye")  #=> "predators_eye"
+    #
+    # @param name [String, Symbol] The name to normalize.
+    # @return [String] The normalized name.
     def self.normalize_name(name)
-      # there are five cases to normalize
-      # "vault_kick", "vault kick", "vault-kick", :vault_kick, :vaultkick
-      # "predator's eye"
-      # if present, convert spaces to underscore; convert all to downcase string
       normal_name = name.to_s.downcase
       normal_name.gsub!(' ', '_') if name =~ (/\s/)
       normal_name.gsub!('-', '_') if name =~ (/-/)
@@ -56,17 +60,34 @@ module Lich
       normal_name
     end
 
-    ## Lifted from LR foreach.lic
-
+    # Generates a unique anonymous hook identifier string.
+    #
+    # @param prefix [String] an optional prefix to include in the identifier (default: '')
+    # @return [String] a unique identifier in the format "Util::<prefix>-<timestamp>-<random_number>"
+    # @example
+    #   Util.anon_hook('event') #=> "Util::event-2024-06-13 12:34:56 +0000-1234"
     def self.anon_hook(prefix = '')
       now = Time.now
       "Util::#{prefix}-#{now}-#{Random.rand(10000)}"
     end
 
+    # Issues a command to the game and captures output between start and end patterns.
+    #
+    # @param command [String] The command to send.
+    # @param start_pattern [Regexp] Pattern marking the start of output capture.
+    # @param end_pattern [Regexp] Pattern marking the end of output capture. Defaults to /<prompt/.
+    # @param include_end [Boolean] Whether to include the end line in the result. Defaults to true.
+    # @param timeout [Integer] Timeout in seconds for the command. Defaults to 5.
+    # @param silent [Boolean, nil] Whether to silence script output. Defaults to nil (no change).
+    # @param usexml [Boolean] Whether to use XML downstream. Defaults to true.
+    # @param quiet [Boolean] If true, suppresses output of lines to FE starting with the start_pattern and ending with the end_pattern. Defaults to false.
+    # @param use_fput [Boolean] If true, uses fput to send the command; otherwise uses put. Defaults to true.
+    # @return [Array<String>] Lines of output captured between start and end patterns.
     def self.issue_command(command, start_pattern, end_pattern = /<prompt/, include_end: true, timeout: 5, silent: nil, usexml: true, quiet: false, use_fput: true)
       result = []
       name = self.anon_hook
       filter = false
+      ignore_end = end_pattern.eql?(:ignore)
 
       save_script_silent = Script.current.silent
       save_want_downstream = Script.current.want_downstream
@@ -80,10 +101,10 @@ module Lich
         Timeout::timeout(timeout, Interrupt) {
           DownstreamHook.add(name, proc { |line|
             if filter
-              if end_pattern.eql?(:ignore) || line =~ end_pattern
+              if ignore_end || line =~ end_pattern
                 DownstreamHook.remove(name)
                 filter = false
-                if quiet && !end_pattern.eql?(:ignore)
+                if quiet && !ignore_end
                   next(nil)
                 else
                   line
@@ -110,12 +131,16 @@ module Lich
 
           until (line = get) =~ start_pattern; end
           result << line.rstrip
-          until (line = get) =~ end_pattern
-            result << line.rstrip
-          end unless end_pattern.eql?(:ignore)
-          if include_end
-            result << line.rstrip
-          end unless end_pattern.eql?(:ignore)
+          unless ignore_end
+            until (line = get) =~ end_pattern
+              result << line.rstrip
+            end
+          end
+          unless ignore_end
+            if include_end
+              result << line.rstrip
+            end
+          end
         }
       rescue Interrupt
         nil
@@ -136,6 +161,17 @@ module Lich
       return issue_command(command, start_pattern, end_pattern, include_end: include_end, timeout: timeout, silent: silent, usexml: false, quiet: true)
     end
 
+    # Retrieves the current silver count from the game output by issuing the 'info' command
+    # and parsing the response. Uses a downstream hook to filter and extract the silver value.
+    #
+    # @param timeout [Integer] the maximum number of seconds to wait for a response (default: 3)
+    # @return [Integer] the amount of silver, or 0 if not found or on timeout
+    #
+    # @example
+    #   silver = Util.silver_count
+    #
+    # This method temporarily silences output, sets up a downstream hook to capture the relevant
+    # lines, and restores the previous silence state after completion.
     def self.silver_count(timeout = 3)
       silence_me unless (undo_silence = silence_me)
       result = ''
@@ -180,8 +216,25 @@ module Lich
       return result.gsub(',', '').to_i
     end
 
-    # Expects hash to be passed to the method.
-    # Each keypair should consist of a gem name and whether to require it after attempting to install gem
+    # Installs and optionally requires a set of Ruby gems specified in a Hash.
+    #
+    # @param gems_to_install [Hash{String => Boolean}]
+    #   A hash where each key is the name of a gem to install (as a String),
+    #   and each value is a Boolean indicating whether to require the gem after installation.
+    #
+    # @raise [ArgumentError]
+    #   If the argument is not a Hash, or if the hash contains keys that are not Strings
+    #   or values that are not TrueClass/FalseClass.
+    #
+    # @raise [RuntimeError]
+    #   If any gems fail to install, raises an error listing the failed gems.
+    #
+    # @example
+    #   install_gem_requirements({ "json" => true, "colorize" => false })
+    #
+    # This method will attempt to install any gems that are not already installed.
+    # If a gem is installed and its value is true, it will be required.
+    # If installation fails for any gem, an error will be raised listing all failed gems.
     def self.install_gem_requirements(gems_to_install)
       raise ArgumentError, "install_gem_requirements must be passed a Hash" unless gems_to_install.is_a?(Hash)
       require "rubygems"


### PR DESCRIPTION
allows to ignore end_pattern, effectively allowing single line capture responses.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `issue_command` in `util.rb` now supports `:ignore` as an `end_pattern`, allowing single line capture responses.
> 
>   - **Behavior**:
>     - `issue_command` in `util.rb` now supports `:ignore` as an `end_pattern`, allowing single line capture responses.
>     - If `end_pattern` is `:ignore`, the end line is not checked or included.
>   - **Functions**:
>     - Updates to `issue_command` to handle `ignore_end` logic.
>   - **Misc**:
>     - Docstring updates for clarity in `util.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=mrhoribu%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 616c3f089ee0bc21ebb569aa183c5da6933930fc. You can [customize](https://app.ellipsis.dev/mrhoribu/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->