### PR TITLE
feat(all): add FrontEnd client support

### DIFF
--- a/lib/common/front-end.rb
+++ b/lib/common/front-end.rb
@@ -64,7 +64,6 @@ module Lich
       end
 
       # Frontend PID tracking functionality
-
       # Get the current frontend PID
       # @return [Integer, nil] The PID if set, nil otherwise
       def self.pid
@@ -387,7 +386,10 @@ module Lich
         @client = value
       end
 
-      alias_method :operating_system, :detect_platform
+      # Alias for detect_platform
+      class << self
+        alias_method :operating_system, :detect_platform
+      end
     end
   end
 end

--- a/lib/common/frontend/warlock.rb
+++ b/lib/common/frontend/warlock.rb
@@ -1,0 +1,51 @@
+module Lich
+  module Common
+    module Frontend
+      module Warlock
+        @file_location = nil
+        @file_name = nil
+        @command_line_args = " --host localhost --port %port% --key %key%"
+
+        def self.exist?
+          case Frontend.operating_system
+          when :windows
+            registry_path = "Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\CurrentVersion\\AppModel\\Repository\\Packages"
+            possible_folder = Registry.open(Registry::HKEY_CURRENT_USER, registry_path).each_key.find { |key| key.to_s =~ /Warlock/ }[0]
+            return false if possible_folder.nil?
+            folder_path = Registry.open(Registry::HKEY_CURRENT_USER, "#{registry_path}\\#{possible_folder}")['PackageRootFolder']
+            if File.exist?(File.join(folder_path))
+              @file_location = File.join(folder_path)
+              @file_name = File.join("warlock3.exe")
+              return true
+            end
+          when :macos
+            if File.exist?(File.join("/Applications/Warlock3.app/Contents/MacOS/Warlock3"))
+              @file_location = File.join("/Applications/Warlock3.app/Contents/MacOS")
+              @file_name = File.join("Warlock3")
+              return true
+            end
+          when :linux
+            if File.exist?(File.join("/usr/bin/warlock3"))
+              @file_location = File.join("/usr/bin")
+              @file_name = File.join("warlock3")
+              return true
+            end
+          end
+          return false
+        end
+
+        def self.file_location
+          @file_location
+        end
+
+        def self.file_name
+          @file_name
+        end
+
+        def self.command_line_args
+          @command_line_args
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for Warlock frontend client with OS detection and configuration in `front-end.rb` and `warlock.rb`.
> 
>   - **Frontend Client Support**:
>     - Adds Warlock client support in `front-end.rb` and new `warlock.rb`.
>     - Detects operating system using `operating_system` method in `front-end.rb`.
>     - Configures Warlock client based on OS in `warlock.rb`.
>   - **New Methods**:
>     - `supports_xml?`, `supports_xml=`, `client`, `client=`, and `operating_system` in `front-end.rb`.
>     - `exist?`, `file_location`, `file_name`, and `command_line_args` in `warlock.rb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=mrhoribu%2Flich-5&utm_source=github&utm_medium=referral)<sup> for 2bc106d944c891e552467c7e11d6f3dfe86597fd. You can [customize](https://app.ellipsis.dev/mrhoribu/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->