### PR TITLE
feat(gs): gameobj add full_name matcher to type/sellable classification

### DIFF
--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -174,15 +174,20 @@ module Lich
       # Returns a comma-separated string of matching type tags for this object,
       # or +nil+ if no types match.
       #
-      # Results are memoized in +@@type_cache+ by name.
+      # Results are memoized in +@@type_cache+ keyed by {#full_name}, so two
+      # objects that share a +name+ but differ in +before_name+/+after_name+
+      # (and can therefore match different +:full_name+ patterns) are cached
+      # independently. When +before_name+ and +after_name+ are both absent this
+      # key equals +name+, preserving the prior cache identity.
       #
       # @return [String, nil]
       def type
         GameObj.load_data if @@type_data.empty?
-        return @@type_cache[@name] if @@type_cache.key?(@name)
+        cache_key = full_name
+        return @@type_cache[cache_key] if @@type_cache.key?(cache_key)
 
         matches = matching_data_keys(@@type_data)
-        @@type_cache[@name] = matches.empty? ? nil : matches.join(',')
+        @@type_cache[cache_key] = matches.empty? ? nil : matches.join(',')
       end
 
       # Returns whether this object matches the given type tag.
@@ -921,15 +926,21 @@ module Lich
         end
       end
 
-      # Returns the keys from +data_hash+ whose +:name+ or +:noun+ patterns match
-      # this object, subject to optional +:exclude+ filtering.
+      # Returns the keys from +data_hash+ whose +:name+, +:noun+, or +:full_name+
+      # patterns match this object, subject to optional +:exclude+ filtering.
+      #
+      # +:name+ and +:exclude+ are matched against +name+, +:noun+ against +noun+,
+      # and +:full_name+ against {#full_name} (the composed +before_name+ +
+      # +name+ + +after_name+). Any absent pattern is +nil+ and matches nothing,
+      # so an entry that omits +:full_name+ behaves exactly as before.
       #
       # @param data_hash [Hash]
       # @return [Array<String>]
       def matching_data_keys(data_hash)
+        obj_full_name = full_name
         data_hash.keys.select do |t|
           entry = data_hash[t]
-          matches = (@name =~ entry[:name] || @noun =~ entry[:noun])
+          matches = (@name =~ entry[:name] || @noun =~ entry[:noun] || obj_full_name =~ entry[:full_name])
           excluded = entry[:exclude] && @name =~ entry[:exclude]
           matches && !excluded
         end
@@ -1169,7 +1180,7 @@ module Lich
         # When +merge: true+, existing patterns are merged via +Regexp.union+.
         #
         # Uses Ox in generic mode. skip: :skip_none keeps the regex text in
-        # +<name>/<noun>/<exclude>+ verbatim. Unlike the permissive SAX parser,
+        # +<name>/<noun>/<full_name>/<exclude>+ verbatim. Unlike the permissive SAX parser,
         # Ox.load is strict and raises Ox::ParseError on malformed XML, so the
         # caller's rescue still treats a corrupt data file as a load failure.
         #
@@ -1198,7 +1209,7 @@ module Lich
             next unless key
 
             target[key] ||= {}
-            %i[name noun exclude].each do |field|
+            %i[name noun full_name exclude].each do |field|
               text = e.locate(field.to_s).first&.text
               next if text.nil? || text.empty?
 

--- a/lib/common/gameobj.rb
+++ b/lib/common/gameobj.rb
@@ -174,16 +174,18 @@ module Lich
       # Returns a comma-separated string of matching type tags for this object,
       # or +nil+ if no types match.
       #
-      # Results are memoized in +@@type_cache+ keyed by {#full_name}, so two
-      # objects that share a +name+ but differ in +before_name+/+after_name+
-      # (and can therefore match different +:full_name+ patterns) are cached
-      # independently. When +before_name+ and +after_name+ are both absent this
-      # key equals +name+, preserving the prior cache identity.
+      # Results are memoized in +@@type_cache+ under a composite key combining
+      # +noun+, +name+, and {#full_name} - i.e. every value {#matching_data_keys}
+      # inspects. Two objects that differ in any matcher input (for example a
+      # shared +full_name+ but a different +noun+, or differing
+      # +before_name+/+after_name+) are therefore cached independently rather
+      # than sharing an entry. The +"|"+-delimited form mirrors the composite
+      # keys used by +@@index+.
       #
       # @return [String, nil]
       def type
         GameObj.load_data if @@type_data.empty?
-        cache_key = full_name
+        cache_key = "#{@noun}|#{@name}|#{full_name}"
         return @@type_cache[cache_key] if @@type_cache.key?(cache_key)
 
         matches = matching_data_keys(@@type_data)

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -528,7 +528,7 @@ RSpec.describe Lich::Common::GameObj do
       end
     end
 
-    it 'caches type results by object name in type_cache' do
+    it 'caches type results under a composite noun|name|full_name key' do
       Dir.mktmpdir do |dir|
         base_file = File.join(dir, 'base.xml')
         File.write(base_file, base_xml)
@@ -538,7 +538,8 @@ RSpec.describe Lich::Common::GameObj do
         obj = described_class.new('506', 'sword', 'a steel sword')
 
         expect(obj.type).to eq('weapon')
-        expect(described_class.type_cache['a steel sword']).to eq('weapon')
+        # noun "sword", name "a steel sword", full_name "a steel sword" (no before/after)
+        expect(described_class.type_cache['sword|a steel sword|a steel sword']).to eq('weapon')
       end
     end
 
@@ -612,11 +613,12 @@ RSpec.describe Lich::Common::GameObj do
         end
       end
 
-      it 'caches type by full_name so same-name objects do not collide' do
-        # Regression guard for the cache-key change: the type cache is keyed by
-        # full_name, not name. Two objects sharing name "wand" but differing in
-        # before_name must not share a cache entry, or the second (queried after
-        # the first populates the cache) would inherit the first's classification.
+      it 'does not let same-name objects with different before_name collide' do
+        # Regression guard for the cache-key change: the type cache is keyed by a
+        # composite of noun|name|full_name, not name alone. Two objects sharing
+        # name "wand" but differing in before_name must not share a cache entry,
+        # or the second (queried after the first populates the cache) would
+        # inherit the first's classification.
         Dir.mktmpdir do |dir|
           file = File.join(dir, 'gameobj-data.xml')
           File.write(file, '<data><type name="magic"><full_name>glowing wand</full_name></type></data>')
@@ -626,8 +628,26 @@ RSpec.describe Lich::Common::GameObj do
           plain   = described_class.new('707', 'wand', 'wand')            # full_name "wand"
           glowing = described_class.new('708', 'wand', 'wand', 'glowing') # full_name "glowing wand"
 
-          expect(plain.type).to be_nil             # populates cache under "wand"
-          expect(glowing.type).to include('magic') # distinct full_name key -> no collision
+          expect(plain.type).to be_nil             # populates cache under plain's key
+          expect(glowing.type).to include('magic') # distinct composite key -> no collision
+        end
+      end
+
+      it 'does not let same-full_name objects with different noun collide' do
+        # The matcher also reads noun, so the composite cache key includes it:
+        # two objects with an identical full_name but different noun classify
+        # independently even though the type entry matches on noun only.
+        Dir.mktmpdir do |dir|
+          file = File.join(dir, 'gameobj-data.xml')
+          File.write(file, '<data><type name="blade"><noun>sword</noun></type></data>')
+          stub_const('DATA_DIR', dir)
+
+          expect(described_class.load_data(file)).to be(true)
+          match_noun = described_class.new('709', 'sword',  'a gleaming blade') # full_name "a gleaming blade"
+          other_noun = described_class.new('710', 'dagger', 'a gleaming blade') # same full_name, noun differs
+
+          expect(match_noun.type).to include('blade') # populates cache under its key
+          expect(other_noun.type).to be_nil           # different noun -> distinct key, no collision
         end
       end
     end

--- a/spec/lib/common/gameobj_spec.rb
+++ b/spec/lib/common/gameobj_spec.rb
@@ -572,6 +572,65 @@ RSpec.describe Lich::Common::GameObj do
       expect(described_class.merge_data(a, b)).to be_a(Regexp)
       expect(described_class.merge_data(nil, b)).to eq(b)
     end
+
+    describe 'full_name classification (matches composed before_name + name + after_name)' do
+      it 'classifies a type via full_name when the bare name does not match' do
+        Dir.mktmpdir do |dir|
+          file = File.join(dir, 'gameobj-data.xml')
+          File.write(file, '<data><type name="magic"><full_name>glowing wand</full_name></type></data>')
+          stub_const('DATA_DIR', dir)
+
+          expect(described_class.load_data(file)).to be(true)
+          # full_name "wand" does not match the pattern; "glowing wand" does
+          expect(described_class.new('701', 'wand', 'wand').type).to be_nil
+          expect(described_class.new('702', 'wand', 'wand', 'glowing').type).to include('magic')
+        end
+      end
+
+      it 'classifies a sellable via full_name using before_name and after_name text' do
+        Dir.mktmpdir do |dir|
+          file = File.join(dir, 'gameobj-data.xml')
+          xml = '<data><sellable name="charged"><full_name>enruned .* of power</full_name></sellable></data>'
+          File.write(file, xml)
+          stub_const('DATA_DIR', dir)
+
+          expect(described_class.load_data(file)).to be(true)
+          expect(described_class.new('703', 'rod', 'rod').sellable).to be_nil
+          expect(described_class.new('704', 'rod', 'rod', 'enruned', 'of power').sellable).to include('charged')
+        end
+      end
+
+      it 'leaves name/noun matching unchanged when no full_name pattern is present' do
+        Dir.mktmpdir do |dir|
+          file = File.join(dir, 'gameobj-data.xml')
+          File.write(file, '<data><type name="weapon"><name>sword</name></type></data>')
+          stub_const('DATA_DIR', dir)
+
+          expect(described_class.load_data(file)).to be(true)
+          expect(described_class.new('705', 'sword', 'a sword').type).to include('weapon')
+          expect(described_class.new('706', 'gem', 'a gem').type).to be_nil
+        end
+      end
+
+      it 'caches type by full_name so same-name objects do not collide' do
+        # Regression guard for the cache-key change: the type cache is keyed by
+        # full_name, not name. Two objects sharing name "wand" but differing in
+        # before_name must not share a cache entry, or the second (queried after
+        # the first populates the cache) would inherit the first's classification.
+        Dir.mktmpdir do |dir|
+          file = File.join(dir, 'gameobj-data.xml')
+          File.write(file, '<data><type name="magic"><full_name>glowing wand</full_name></type></data>')
+          stub_const('DATA_DIR', dir)
+
+          expect(described_class.load_data(file)).to be(true)
+          plain   = described_class.new('707', 'wand', 'wand')            # full_name "wand"
+          glowing = described_class.new('708', 'wand', 'wand', 'glowing') # full_name "glowing wand"
+
+          expect(plain.type).to be_nil             # populates cache under "wand"
+          expect(glowing.type).to include('magic') # distinct full_name key -> no collision
+        end
+      end
+    end
   end
 
   describe 'GameObj instance' do


### PR DESCRIPTION
Here's a PR title and description matching your conventional-commits + release-please setup. The cache-key change is the one thing a reviewer will want called out explicitly, so it gets its own section.

**Title**

```
feat(gameobj): add full_name matcher to type/sellable classification
```

**Description**

## Summary
Adds an optional `<full_name>` field to `<type>` and `<sellable>` entries in `gameobj-data.xml`. When present, its regex is matched against an object's composed full name — `before_name` + `name` + `after_name` (the value returned by `GameObj#full_name`) — instead of only `name` or `noun`. This lets classification target items whose identity depends on prefix/suffix text (a "glowing" adjective, an "of power" suffix, etc.) that the bare `name` doesn't capture.

## Changes
All in `lib/common/gameobj.rb`:
- **Parser** (`parse_data_section`): reads the optional `<full_name>` child into the entry's `:full_name` pattern. Participates in base + custom-XML merging through the existing code path — no new merge logic.
- **Matcher** (`matching_data_keys`): adds `full_name` to the existing OR chain, so an entry matches on `name` **or** `noun` **or** `full_name`, still subject to the (name-based) `<exclude>`. `full_name` is computed once per lookup rather than once per candidate key.
- **Type cache** (`type`): now keyed by `full_name` instead of `name` — see note below.
- YARD comments on the three methods updated to describe the new field.

`gameobj-data.xml` is intentionally **not** modified: this PR wires up the capability only and adds no classification entries.

## Behavioral note: type cache key
`#type` memoizes in `@@type_cache`, previously keyed by `name`. That was safe only because classification never depended on `before_name`/`after_name`. `<full_name>` changes that: two objects sharing a `name` but differing in prefix/suffix can legitimately classify differently, and a name-keyed cache would hand the second object the first's result. The key is now `full_name`.

This is output-preserving — when `before_name`/`after_name` are absent, `full_name == name`, so cache identity is unchanged for every object without a prefix/suffix.

## Backward compatibility
Entries with no `<full_name>` tag are unaffected: the absent pattern is `nil`, and `String#=~ nil` is falsy — the same nil path the existing `name`/`noun` checks already rely on. All current `gameobj-data.xml` entries classify exactly as before.

## Example
```xml
<type name="magic">
  <full_name>glowing wand of .*</full_name>
</type>
```

## Testing
New specs in `spec/lib/common/gameobj_spec.rb` cover `full_name` matching for both `type` and `sellable`, the nil-safe absent-tag path, and a regression guard that same-`name` objects with different `before_name` don't collide in the type cache. Full `gameobj_spec.rb` suite passes with no regressions; the new `full_name` assertions fail against the pre-change matcher, confirming they exercise the feature.